### PR TITLE
Added the travis npm script back in

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "url": "http://github.com/DamonOehlman/sharedconfig/issues"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --reporter spec --timeout 20000"
+    "test": "./node_modules/.bin/mocha --reporter spec",
+    "travis": "NODE_ENV=travis ./node_modules/.bin/mocha --reporter spec --timeout 20000"
   },
   "contributors": [],
   "optionalDependencies": {}


### PR DESCRIPTION
Required for travis to call tests. I did have this in here before but somehow it got lost. 

Travis says sharedconfig is passing the tests but that would be because it's not running any tests ...
